### PR TITLE
Add an action to build and push docker image to github container registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/vizmo-vms/deepface:latest
+            ghcr.io/vizmo-vms/deepface:${{ github.run_id }}-${{ github.sha }}
+            ghcr.io/vizmo-vms/deepface:$(date +'%Y%m%d')


### PR DESCRIPTION
Add a GitHub Actions workflow to build and push Docker images to GitHub Container Registry.

* **New Workflow File**: Add `.github/workflows/docker-image.yml` to define the workflow.
* **Trigger**: Set the workflow to trigger on push to the main branch.
* **Steps**:
  - Checkout the repository.
  - Set up Docker Buildx.
  - Log in to GitHub Container Registry using `GITHUB_TOKEN`.
  - Build and push the Docker image with tags `latest`, `${{ github.run_id }}-${{ github.sha }}`, and the current date without `-`.

